### PR TITLE
chore(package): update Node.js engine requirement and improve build s…

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -112,7 +112,7 @@
   "author": "Scholar-Flow Team",
   "license": "UNLICENSED",
   "engines": {
-    "node": ">=22.0.0",
+    "node": ">=24.0.0",
     "yarn": ">=4.9.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   },
   "license": "UNLICENSED",
   "engines": {
-    "node": ">=22.0.0",
+    "node": ">=24.0.0",
     "yarn": ">=4.9.2"
   },
   "packageManager": "yarn@4.9.2",

--- a/render-build.sh
+++ b/render-build.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
-# Render build script — enables Corepack so Yarn 4.9.2 is used
-# instead of the global Yarn 1.x (which rejects packageManager field).
+# Render build script — uses Corepack's built-in proxy to run Yarn 4.9.2
+# instead of the global Yarn 1.x. Avoids `corepack enable` which needs
+# write access to /usr/bin (read-only on Render).
 set -euo pipefail
 
-corepack enable
-yarn install --immutable
-yarn build
+corepack yarn install --immutable
+corepack yarn build


### PR DESCRIPTION
…cript

- Updated Node.js engine requirement in package.json files to version 24.0.0 for better compatibility.
- Modified render-build.sh to utilize Corepack's built-in proxy for Yarn 4.9.2, avoiding the need for write access to /usr/bin.