### PR TITLE
refactor(api): centralize API base URL resolution in lib/apiUrl.ts

### DIFF
--- a/apps/frontend/.env.example
+++ b/apps/frontend/.env.example
@@ -1,3 +1,13 @@
+# =============================================================================
+# Scholar-Flow Frontend Environment Variables
+# =============================================================================
+# All API URLs are resolved via src/lib/apiUrl.ts (single source of truth).
+# Resolution: NEXT_PUBLIC_API_BASE_URL → NEXT_PUBLIC_SITE_URL/api → localhost:5000/api
+#
+# For Vercel (scholar-flow-ai.vercel.app):
+#   Set these in Project Settings → Environment Variables (NOT just in .env.production)
+# =============================================================================
+
 # better-auth Configuration
 BETTER_AUTH_SECRET="your-better-auth-secret-here"
 NEXTAUTH_SECRET="your-nextauth-secret-here"

--- a/apps/frontend/src/app/api/auth/register/route.ts
+++ b/apps/frontend/src/app/api/auth/register/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { API_BASE_URL } from "@/lib/apiUrl";
 
 export async function POST(req: NextRequest) {
   try {
@@ -22,8 +23,7 @@ export async function POST(req: NextRequest) {
     }
 
     // Call backend API
-    const apiBaseUrl =
-      process.env.NEXT_PUBLIC_API_BASE_URL || "http://localhost:5000/api";
+    const apiBaseUrl = API_BASE_URL;
     const response = await fetch(`${apiBaseUrl}/auth/register`, {
       method: "POST",
       headers: {

--- a/apps/frontend/src/app/auth/callback/magic-link/page.tsx
+++ b/apps/frontend/src/app/auth/callback/magic-link/page.tsx
@@ -7,7 +7,7 @@ import { useRouter, useSearchParams } from "next/navigation";
 import { useEffect, useRef } from "react";
 import type { TUser } from "@/types/user";
 
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL || "http://localhost:5000/api";
+import { API_BASE_URL } from "@/lib/apiUrl";
 
 export default function MagicLinkCallbackPage() {
   const router = useRouter();

--- a/apps/frontend/src/app/debug-auth/page.tsx
+++ b/apps/frontend/src/app/debug-auth/page.tsx
@@ -10,6 +10,7 @@ import { useAuth } from "@/redux/auth/useAuth";
 import { useAppDispatch } from "@/redux/hooks";
 import { AlertCircle, CheckCircle2, XCircle } from "lucide-react";
 import { useState } from "react";
+import { getApiBaseUrl, API_BASE_URL } from "@/lib/apiUrl";
 
 export default function AuthDebugPage() {
   const { session, status } = useAuth();
@@ -43,8 +44,7 @@ export default function AuthDebugPage() {
 
   const testBackendConnection = async () => {
     try {
-      const apiUrl =
-        process.env.NEXT_PUBLIC_API_BASE_URL || "http://localhost:5000/api";
+      const apiUrl = getApiBaseUrl();
       const response = await fetch(`${apiUrl.replace("/api", "")}/health`);
       const data = await response.json();
       alert(
@@ -57,8 +57,7 @@ export default function AuthDebugPage() {
 
   const testBackendAuth = async () => {
     try {
-      const apiUrl =
-        process.env.NEXT_PUBLIC_API_BASE_URL || "http://localhost:5000/api";
+      const apiUrl = getApiBaseUrl();
       const response = await fetch(`${apiUrl}/auth/signin`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -231,8 +230,7 @@ export default function AuthDebugPage() {
             <p>
               <strong>API Base URL:</strong>{" "}
               <code className="bg-muted px-2 py-1 rounded">
-                {process.env.NEXT_PUBLIC_API_BASE_URL ||
-                  "http://localhost:5000/api"}
+                {API_BASE_URL}
               </code>
             </p>
           </div>

--- a/apps/frontend/src/app/invitation/[token]/page.tsx
+++ b/apps/frontend/src/app/invitation/[token]/page.tsx
@@ -11,8 +11,7 @@ import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useCallback, useEffect, useState } from "react";
 
-const API_BASE_URL =
-  process.env.NEXT_PUBLIC_API_BASE_URL || "http://localhost:5000/api";
+import { API_BASE_URL } from "@/lib/apiUrl";
 
 interface InvitationData {
   id: string;

--- a/apps/frontend/src/app/login/page.tsx
+++ b/apps/frontend/src/app/login/page.tsx
@@ -35,8 +35,7 @@ import { useState, useEffect } from "react";
 import { useForm, Controller } from "react-hook-form";
 import { z } from "zod";
 
-const API_BASE_URL =
-  process.env.NEXT_PUBLIC_API_BASE_URL || "http://localhost:5000/api";
+import { API_BASE_URL } from "@/lib/apiUrl";
 
 const loginSchema = z.object({
   email: z.string().email("Please enter a valid email address"),

--- a/apps/frontend/src/app/public-view/[id]/page.tsx
+++ b/apps/frontend/src/app/public-view/[id]/page.tsx
@@ -1,12 +1,12 @@
 import { Metadata } from "next";
 import { notFound } from "next/navigation";
+import { API_BASE_URL as apiUrl } from "@/lib/apiUrl";
 
 interface Props {
   params: Promise<{ id: string }>;
 }
 
 async function getPublishedPaper(id: string) {
-  const apiUrl = process.env.NEXT_PUBLIC_API_BASE_URL || "http://localhost:5000/api";
   try {
     const res = await fetch(`${apiUrl}/public/editor/${id}`, {
       next: { revalidate: 60 },

--- a/apps/frontend/src/components/customUI/LatexFileTree.tsx
+++ b/apps/frontend/src/components/customUI/LatexFileTree.tsx
@@ -30,7 +30,7 @@ interface Props {
   onCompile: () => void;
 }
 
-const API_BASE = process.env.NEXT_PUBLIC_API_BASE_URL || "http://localhost:5000/api";
+import { API_BASE_URL as API_BASE } from "@/lib/apiUrl";
 
 function getToken(): string | null {
   try {

--- a/apps/frontend/src/hooks/useNotificationStream.ts
+++ b/apps/frontend/src/hooks/useNotificationStream.ts
@@ -13,6 +13,7 @@
  */
 
 import { useEffect, useRef } from "react";
+import { getApiBaseUrl } from "@/lib/apiUrl";
 import { useSelector } from "react-redux";
 import { useDispatch } from "react-redux";
 import type { RootState } from "@/redux/store";
@@ -80,7 +81,7 @@ export function useNotificationStream(
     const connect = () => {
       if (closed) return;
       const base =
-        process.env.NEXT_PUBLIC_API_BASE_URL || "http://localhost:5000/api";
+        getApiBaseUrl();
       const url = `${base}/notifications/stream?token=${encodeURIComponent(
         accessToken
       )}`;

--- a/apps/frontend/src/lib/api/streamingFetch.ts
+++ b/apps/frontend/src/lib/api/streamingFetch.ts
@@ -8,8 +8,7 @@
  */
 import { getAppStore } from "@/redux/storeAccess";
 
-const API_BASE_URL =
-  process.env.NEXT_PUBLIC_API_BASE_URL || "http://localhost:5000/api";
+import { API_BASE_URL } from "@/lib/apiUrl";
 
 export interface AuthedFetchOptions extends Omit<RequestInit, "body"> {
   body?: unknown;

--- a/apps/frontend/src/lib/apiUrl.ts
+++ b/apps/frontend/src/lib/apiUrl.ts
@@ -1,0 +1,52 @@
+/**
+ * Centralized API base URL resolver.
+ * Use this import instead of inlining process.env.NEXT_PUBLIC_API_BASE_URL.
+ *
+ * Resolution order:
+ *   1. NEXT_PUBLIC_API_BASE_URL (explicit — set in Vercel dashboard for production)
+ *   2. NEXT_PUBLIC_SITE_URL + "/api" (derived — works when backend is co-deployed)
+ *   3. localhost:5000/api (development fallback only)
+ *
+ * For production, set NEXT_PUBLIC_API_BASE_URL to your backend URL.
+ * Example: NEXT_PUBLIC_API_BASE_URL="https://scholar-flow-api.vercel.app/api"
+ */
+
+let _cachedApiUrl: string | undefined;
+
+export function getApiBaseUrl(): string {
+  if (_cachedApiUrl) return _cachedApiUrl;
+
+  const explicit = process.env.NEXT_PUBLIC_API_BASE_URL;
+  if (explicit) {
+    _cachedApiUrl = explicit;
+    return explicit;
+  }
+
+  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL;
+  if (siteUrl) {
+    _cachedApiUrl = `${siteUrl.replace(/\/+$/, "")}/api`;
+    if (typeof window !== "undefined") {
+      console.log(
+        `[apiUrl] Derived API URL from NEXT_PUBLIC_SITE_URL: ${_cachedApiUrl}`
+      );
+    }
+    return _cachedApiUrl;
+  }
+
+  // Production: warn if no API URL configured
+  if (
+    process.env.NODE_ENV === "production" &&
+    typeof window !== "undefined"
+  ) {
+    console.error(
+      "[apiUrl] NEXT_PUBLIC_API_BASE_URL is not set! OAuth and API calls will fail. " +
+        "Set it in your Vercel project settings."
+    );
+  }
+
+  _cachedApiUrl = "http://localhost:5000/api";
+  return _cachedApiUrl;
+}
+
+/** Convenience export — the resolved API base URL string */
+export const API_BASE_URL = getApiBaseUrl();

--- a/apps/frontend/src/lib/auth/authHelpers.ts
+++ b/apps/frontend/src/lib/auth/authHelpers.ts
@@ -8,8 +8,7 @@ import type { AppDispatch } from "@/redux/store";
 import { getPersistor } from "@/redux/storeAccess";
 import type { TUser } from "@/types/user";
 
-const API_BASE_URL =
-  process.env.NEXT_PUBLIC_API_BASE_URL || "http://localhost:5000/api";
+import { API_BASE_URL } from "@/lib/apiUrl";
 
 interface AuthResponse {
   success: boolean;

--- a/apps/frontend/src/lib/auth/better-auth.ts
+++ b/apps/frontend/src/lib/auth/better-auth.ts
@@ -8,8 +8,7 @@ import { betterAuth } from "better-auth";
 import { nextCookies } from "better-auth/next-js";
 import { randomBytes } from "crypto";
 
-const API_BASE_URL =
-  process.env.NEXT_PUBLIC_API_BASE_URL || "http://localhost:5000/api";
+import { API_BASE_URL } from "@/lib/apiUrl";
 
 /**
  * Resolve the auth secret. In production, BETTER_AUTH_SECRET or NEXTAUTH_SECRET must be set.

--- a/apps/frontend/src/lib/auth/signout.ts
+++ b/apps/frontend/src/lib/auth/signout.ts
@@ -24,8 +24,7 @@ import { apiSlice } from "@/redux/api/apiSlice";
 import { clearCredentials } from "@/redux/auth/authSlice";
 import { getAppStore, getPersistor } from "@/redux/storeAccess";
 
-const API_BASE_URL =
-  process.env.NEXT_PUBLIC_API_BASE_URL || "http://localhost:5000/api";
+import { API_BASE_URL } from "@/lib/apiUrl";
 
 // better-auth cookies to clear. We only know the client-side names; the
 // server-side Set-Cookie response is what better-auth uses to clear them.

--- a/apps/frontend/src/lib/tiptap-utils.ts
+++ b/apps/frontend/src/lib/tiptap-utils.ts
@@ -1,4 +1,5 @@
 import { getAppStore } from "@/redux/storeAccess";
+import { getApiBaseUrl } from "@/lib/apiUrl";
 import type { Node as TiptapNode } from "@tiptap/pm/model";
 import { NodeSelection, Selection, TextSelection } from "@tiptap/pm/state";
 import type { Editor } from "@tiptap/react";
@@ -408,7 +409,7 @@ export const handleImageUpload = async (
 
       // Configure request
       const apiBaseUrl =
-        process.env.NEXT_PUBLIC_API_BASE_URL || "http://localhost:5000/api";
+        getApiBaseUrl();
       xhr.open("POST", `${apiBaseUrl}/editor/upload-image`);
 
       // Add auth header

--- a/apps/frontend/src/redux/api/apiSlice.ts
+++ b/apps/frontend/src/redux/api/apiSlice.ts
@@ -4,6 +4,7 @@ import {
   FetchBaseQueryError,
 } from "@reduxjs/toolkit/query/react";
 import type { RootState } from "../store";
+import { API_BASE_URL } from "@/lib/apiUrl";
 
 // Enhanced error response interface
 export interface ApiErrorResponse {
@@ -54,7 +55,7 @@ const transformErrorResponse = (
 };
 
 const baseQuery = fetchBaseQuery({
-  baseUrl: process.env.NEXT_PUBLIC_API_BASE_URL || "http://localhost:5000/api",
+  baseUrl: API_BASE_URL,
   prepareHeaders: (headers, { getState, endpoint }) => {
     // Get token from Redux auth state
     const token = (getState() as RootState).auth.accessToken;


### PR DESCRIPTION
- Create lib/apiUrl.ts as single source of truth for API URL resolution
- Resolution order: NEXT_PUBLIC_API_BASE_URL → NEXT_PUBLIC_SITE_URL/api → localhost:5000/api
- Logs clear error in production if NEXT_PUBLIC_API_BASE_URL is missing
- Update all 15 files (17 occurrences) to import from centralized module
- Eliminate 'localhost:5000' hardcoded fallback duplication
- Update .env.example with Vercel deployment documentation