### PR TITLE
fix(apiUrl): read NEXT_PUBLIC env vars at module top level for Turbop…

### DIFF
--- a/apps/frontend/src/lib/apiUrl.ts
+++ b/apps/frontend/src/lib/apiUrl.ts
@@ -1,50 +1,61 @@
 /**
  * Centralized API base URL resolver.
- * Use this import instead of inlining process.env.NEXT_PUBLIC_API_BASE_URL.
+ *
+ * **CRITICAL**: process.env.NEXT_PUBLIC_* vars are read at MODULE TOP LEVEL.
+ * This is required for Next.js/Turbopack to inline them into the client bundle
+ * at build time. Do NOT read them inside function bodies.
  *
  * Resolution order:
- *   1. NEXT_PUBLIC_API_BASE_URL (explicit — set in Vercel dashboard for production)
- *   2. NEXT_PUBLIC_SITE_URL + "/api" (derived — works when backend is co-deployed)
- *   3. localhost:5000/api (development fallback only)
+ *   1. NEXT_PUBLIC_API_BASE_URL (explicit — set in Vercel dashboard)
+ *   2. NEXT_PUBLIC_SITE_URL + "/api" (derived)
+ *   3. localhost:5000/api (development only)
  *
- * For production, set NEXT_PUBLIC_API_BASE_URL to your backend URL.
- * Example: NEXT_PUBLIC_API_BASE_URL="https://scholar-flow-api.vercel.app/api"
+ * For Vercel production, set in Project Settings → Environment Variables:
+ *   NEXT_PUBLIC_API_BASE_URL = https://scholar-flow-api.vercel.app/api
+ *   NEXT_PUBLIC_SITE_URL     = https://scholar-flow-ai.vercel.app
  */
 
-let _cachedApiUrl: string | undefined;
+// Must be read at module TOP LEVEL for Next.js to inline into client bundles
+const ENV_API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL;
+const ENV_SITE_URL = process.env.NEXT_PUBLIC_SITE_URL;
+const ENV_NODE_ENV = process.env.NODE_ENV;
 
-export function getApiBaseUrl(): string {
-  if (_cachedApiUrl) return _cachedApiUrl;
+let _cachedApiUrl: string | null = null;
 
-  const explicit = process.env.NEXT_PUBLIC_API_BASE_URL;
-  if (explicit) {
-    _cachedApiUrl = explicit;
-    return explicit;
+function resolveApiBaseUrl(): string {
+  if (ENV_API_BASE_URL) {
+    return ENV_API_BASE_URL;
   }
 
-  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL;
-  if (siteUrl) {
-    _cachedApiUrl = `${siteUrl.replace(/\/+$/, "")}/api`;
-    if (typeof window !== "undefined") {
-      console.log(
-        `[apiUrl] Derived API URL from NEXT_PUBLIC_SITE_URL: ${_cachedApiUrl}`
-      );
-    }
-    return _cachedApiUrl;
+  if (ENV_SITE_URL) {
+    const derived = `${ENV_SITE_URL.replace(/\/+$/, "")}/api`;
+    return derived;
   }
 
-  // Production: warn if no API URL configured
-  if (
-    process.env.NODE_ENV === "production" &&
-    typeof window !== "undefined"
-  ) {
+  // Only log in browser context (not during SSR)
+  if (ENV_NODE_ENV === "production" && typeof window !== "undefined") {
     console.error(
-      "[apiUrl] NEXT_PUBLIC_API_BASE_URL is not set! OAuth and API calls will fail. " +
-        "Set it in your Vercel project settings."
+      "[apiUrl] NEXT_PUBLIC_API_BASE_URL is not set! " +
+        "API calls and OAuth will fail. " +
+        "Set it in Vercel project settings."
     );
   }
 
-  _cachedApiUrl = "http://localhost:5000/api";
+  return "http://localhost:5000/api";
+}
+
+export function getApiBaseUrl(): string {
+  if (_cachedApiUrl) return _cachedApiUrl;
+  _cachedApiUrl = resolveApiBaseUrl();
+
+  if (typeof window !== "undefined") {
+    console.log(
+      `[apiUrl] Resolved API URL: ${_cachedApiUrl} ` +
+        `(NEXT_PUBLIC_API_BASE_URL=${ENV_API_BASE_URL || "unset"}, ` +
+        `NEXT_PUBLIC_SITE_URL=${ENV_SITE_URL || "unset"})`
+    );
+  }
+
   return _cachedApiUrl;
 }
 


### PR DESCRIPTION
…ack inlining

- Move process.env.NEXT_PUBLIC_* reads to module top-level constants
- Inside function bodies, Turbopack may not inline them into client bundles
- Add browser console debug log showing resolved URL for verification
- Kept backward-compatible: same getApiBaseUrl() / API_BASE_URL exports