### PR TITLE
fix(vercel): add missing corepack enable to frontend installCommand

### DIFF
--- a/apps/frontend/vercel.json
+++ b/apps/frontend/vercel.json
@@ -2,7 +2,7 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "version": 2,
   "framework": "nextjs",
-  "buildCommand": "cd ../.. && corepack yarn workspace @scholar-flow/frontend build",
-  "installCommand": "cd ../.. && corepack yarn install --immutable",
+  "buildCommand": "cd ../.. && corepack enable && corepack yarn workspace @scholar-flow/frontend build",
+  "installCommand": "cd ../.. && corepack enable && corepack yarn install --immutable",
   "outputDirectory": ".next"
 }


### PR DESCRIPTION
- Vercel requires 'corepack enable' before 'yarn install --immutable'
- Backend vercel.json already had it, frontend was missing
- Fixes 'yarn install --immutable' exit code 1 on Vercel deploy