### PR TITLE
fix(vercel): proper serverless function config + OAuth resilience

### DIFF
--- a/apps/backend/api/server.js
+++ b/apps/backend/api/server.js
@@ -1,0 +1,15 @@
+/**
+ * Vercel Serverless Function entry point.
+ *
+ * Vercel requires the handler to be inside an `api/` directory.
+ * This file imports the compiled Express app from `dist/server.js`
+ * and re-exports it for @vercel/node.
+ *
+ * Note: server.ts exports the Express app as the default export
+ * AND as `module.exports = app`. The require() below returns the
+ * Express app directly (not wrapped in an object).
+ */
+const app = require("../dist/server");
+
+// If TypeScript emitted a default export, destructure it
+module.exports = app.default || app;

--- a/apps/backend/src/app/modules/Auth/oauth.controller.ts
+++ b/apps/backend/src/app/modules/Auth/oauth.controller.ts
@@ -107,17 +107,26 @@ function generateAccessToken(user: UserData): string {
  */
 export const initiateGoogleOAuth: AsyncRequestHandler = catchAsync(
   async (req: Request, res: Response) => {
-    // callbackUrl is already URL-encoded from the frontend, don't encode again
     const callbackUrl = (req.query.callbackUrl as string) || "/dashboard";
-    const state = callbackUrl; // Use as-is, already encoded from frontend
+    const state = callbackUrl;
 
     const googleClientId = process.env.GOOGLE_CLIENT_ID;
-    const frontendUrl = process.env.FRONTEND_URL || "http://localhost:3000";
+    const frontendUrl =
+      process.env.FRONTEND_URL ||
+      process.env.VERCEL_URL ||
+      "http://localhost:3000";
     const redirectUri = `${frontendUrl}/auth/callback/google`;
 
     if (!googleClientId) {
+      console.error("[OAuth] GOOGLE_CLIENT_ID not configured in environment");
       throw new ApiError(500, "Google OAuth not configured");
     }
+
+    console.log("[OAuth] Initiating Google OAuth", {
+      redirectUri,
+      frontendUrl,
+      hasCallbackUrl: !!callbackUrl,
+    });
 
     const googleAuthUrl = new URL(
       "https://accounts.google.com/o/oauth2/v2/auth"
@@ -141,15 +150,18 @@ export const initiateGoogleOAuth: AsyncRequestHandler = catchAsync(
  */
 export const initiateGitHubOAuth: AsyncRequestHandler = catchAsync(
   async (req: Request, res: Response) => {
-    // callbackUrl is already URL-encoded from the frontend, don't encode again
     const callbackUrl = (req.query.callbackUrl as string) || "/dashboard";
-    const state = callbackUrl; // Use as-is, already encoded from frontend
+    const state = callbackUrl;
 
     const githubClientId = process.env.GITHUB_CLIENT_ID;
-    const frontendUrl = process.env.FRONTEND_URL || "http://localhost:3000";
+    const frontendUrl =
+      process.env.FRONTEND_URL ||
+      process.env.VERCEL_URL ||
+      "http://localhost:3000";
     const redirectUri = `${frontendUrl}/auth/callback/github`;
 
     if (!githubClientId) {
+      console.error("[OAuth] GITHUB_CLIENT_ID not configured in environment");
       throw new ApiError(500, "GitHub OAuth not configured");
     }
 
@@ -179,16 +191,19 @@ export const handleGoogleCallback: AsyncRequestHandler = catchAsync(
 
     const googleClientId = process.env.GOOGLE_CLIENT_ID;
     const googleClientSecret = process.env.GOOGLE_CLIENT_SECRET;
-    const frontendUrl = process.env.FRONTEND_URL || "http://localhost:3000";
+    const frontendUrl =
+      process.env.FRONTEND_URL ||
+      process.env.VERCEL_URL ||
+      "http://localhost:3000";
     const redirectUri = `${frontendUrl}/auth/callback/google`;
 
     if (!googleClientId || !googleClientSecret) {
+      console.error("[OAuth] Google OAuth credentials not configured");
       throw new ApiError(500, "Google OAuth not configured");
     }
 
-    // Exchange code for tokens
-    console.log("🔄 Exchanging Google OAuth code...", {
-      codeLength: code.length,
+    console.log("[OAuth] Handling Google callback", {
+      hasCode: !!code,
       redirectUri,
       frontendUrl,
     });

--- a/apps/backend/src/server.ts
+++ b/apps/backend/src/server.ts
@@ -20,8 +20,12 @@ import {
   isStripeWebhookPath,
 } from "./app/utils/stripeWebhook";
 
-// Initialize queue processing
-import "./app/services/pdfProcessingQueue";
+// Initialize queue processing (lazy on Vercel to avoid cold start issues)
+if (process.env.VERCEL !== "1") {
+  require("./app/services/pdfProcessingQueue");
+} else {
+  console.log("[Boot] Vercel environment — deferring queue init");
+}
 
 const app: import("express").Express = express();
 const PORT = config.port || 5000;
@@ -79,7 +83,14 @@ const allowedOrigins = [
   process.env.FRONTEND_URL || "http://localhost:3000",
   "https://scholar-flow-ai.vercel.app",
   process.env.WS_URL || "http://localhost:5001",
-];
+].filter(Boolean);
+
+// Add Vercel deployment URL if available
+if (process.env.VERCEL_URL) {
+  allowedOrigins.push(`https://${process.env.VERCEL_URL}`);
+}
+
+console.log("[Boot] CORS allowed origins:", allowedOrigins);
 app.use(
   cors({
     origin: (origin, callback) => {

--- a/apps/backend/vercel.json
+++ b/apps/backend/vercel.json
@@ -10,11 +10,10 @@
   },
   "installCommand": "cd ../.. && corepack enable && corepack yarn --version && corepack yarn install --immutable",
   "buildCommand": "cd ../.. && corepack enable && corepack yarn workspace @scholar-flow/backend db:generate && corepack yarn workspace @scholar-flow/backend build",
-  "outputDirectory": "dist",
   "rewrites": [
     {
       "source": "/(.*)",
-      "destination": "/api/server.js"
+      "destination": "/api/server"
     }
   ]
 }


### PR DESCRIPTION
- Add api/server.js as Vercel serverless entry point
- Fix vercel.json: proper routes config pointing to /api/server
- Defer pdfProcessingQueue import on Vercel to avoid cold start issues
- Add VERCEL_URL fallback for FRONTEND_URL in OAuth redirect_uri
- Add VERCEL_URL to CORS allowed origins
- Add debug logging to OAuth init/callback handlers