### PR TITLE
fix(vercel): add outputDirectory back to backend vercel.json

### DIFF
--- a/apps/backend/vercel.json
+++ b/apps/backend/vercel.json
@@ -10,6 +10,7 @@
   },
   "installCommand": "cd ../.. && corepack enable && corepack yarn --version && corepack yarn install --immutable",
   "buildCommand": "cd ../.. && corepack enable && corepack yarn workspace @scholar-flow/backend db:generate && corepack yarn workspace @scholar-flow/backend build",
+  "outputDirectory": "dist",
   "rewrites": [
     {
       "source": "/(.*)",


### PR DESCRIPTION
- Vercel requires outputDirectory when using buildCommand
- Missing outputDirectory caused 'No Output Directory named public found' error
- Point to dist/ where tsc outputs the compiled Express app