### PR TITLE
fix(vercel): add includeFiles for function bundling + crash diagnostics

### DIFF
--- a/apps/backend/api/server.js
+++ b/apps/backend/api/server.js
@@ -5,11 +5,33 @@
  * This file imports the compiled Express app from `dist/server.js`
  * and re-exports it for @vercel/node.
  *
- * Note: server.ts exports the Express app as the default export
- * AND as `module.exports = app`. The require() below returns the
- * Express app directly (not wrapped in an object).
+ * Required environment variables:
+ *   DIRECT_DATABASE_URL or DATABASE_URL — PostgreSQL connection string
+ *   JWT_SECRET                          — JWT signing key
+ *   FRONTEND_URL                        — e.g. https://scholar-flow-ai.vercel.app
+ *   AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_BUCKET_NAME, AWS_REGION
+ *   (AI, Stripe, Redis keys optional — app degrades gracefully)
  */
-const app = require("../dist/server");
+
+let app;
+try {
+  app = require("../dist/server");
+} catch (err) {
+  console.error("[FATAL] Failed to load dist/server.js:", err.message);
+  if (err.code === "MODULE_NOT_FOUND") {
+    console.error("[FATAL] Module resolution error. Check that build completed and includeFiles is configured.");
+    console.error("[FATAL] Missing module:", err.message.split("\n")[0]);
+  }
+  console.error("[FATAL] Stack:", err.stack);
+  throw err;
+}
 
 // If TypeScript emitted a default export, destructure it
-module.exports = app.default || app;
+const handler = app.default || app;
+
+if (!handler || typeof handler !== "function") {
+  console.error("[FATAL] dist/server.js did not export a valid Express app. typeof:", typeof handler);
+  throw new Error("Invalid Express app export from dist/server.js");
+}
+
+module.exports = handler;

--- a/apps/backend/vercel.json
+++ b/apps/backend/vercel.json
@@ -11,6 +11,11 @@
   "installCommand": "cd ../.. && corepack enable && corepack yarn --version && corepack yarn install --immutable",
   "buildCommand": "cd ../.. && corepack enable && corepack yarn workspace @scholar-flow/backend db:generate && corepack yarn workspace @scholar-flow/backend build",
   "outputDirectory": "dist",
+  "functions": {
+    "api/server.js": {
+      "includeFiles": "dist/**"
+    }
+  },
   "rewrites": [
     {
       "source": "/(.*)",


### PR DESCRIPTION
Step 0 of AI overhaul — Fix FUNCTION_INVOCATION_FAILED on backend.

Root cause: Vercel function bundler doesn't trace require() calls outside the api/ directory by default. Without explicit includeFiles, dist/server.js and all its imported modules are absent from the function sandbox at runtime, causing MODULE_NOT_FOUND and crash.

Changes:
- vercel.json: Add functions.includeFiles to bundle dist/** into the api/server.js function sandbox
- api/server.js: Add try/catch with FATAL logging to surface the actual crash error in Vercel logs, validate Express app export, document required env vars